### PR TITLE
Squad Rover Parts - Temp too low

### DIFF
--- a/DeadlyReentry/DeadlyReentry.cfg
+++ b/DeadlyReentry/DeadlyReentry.cfg
@@ -881,7 +881,7 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 }
 @PART[roverBody]
 {
-	@maxTemp = 600
+	@maxTemp = 1600
 }
 @PART[sensorAccelerometer]
 {
@@ -963,7 +963,7 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 }
 @PART[roverWheel3]
 {
-	@maxTemp = 600
+	@maxTemp = 1600
 }
 @PART[wheelMed]
 {


### PR DESCRIPTION
Not sure if this was intentional or if a number was missed, but having the roverbody and roverwheel3 set to 600 max temp makes them have the lowest temperature allowance of any Squad part, and it's been impossible to launch a rover in my 6.4x installation without these changes.