### PR TITLE
Dev

### DIFF
--- a/DeadlyReentry/DeadlyReentry-HOME.cfg
+++ b/DeadlyReentry/DeadlyReentry-HOME.cfg
@@ -58,22 +58,16 @@
 	@maxTemp = 2000
 	MODULE
 	{
-		// Most of these if unspecified default to the corresponding part field.
-		// skinMaxTemp
-		// skinThermalMassModifier
-		// skinThicknessFactor = 0.1
-		// skinHeatConductivity = 0.12
-		// skinThermalMass
-
 		name = ModuleHeatShield
 		ablativeResource = AblativeShielding
-		lossExp = -5000
-		lossConst = 20
-		pyrolysisLossFactor = 1000
+		lossExp = -6000
+		lossConst = 5
+		pyrolysisLossFactor = 120
 		reentryConductivity = 0.01
-		ablationTempThresh = 400
-		charMin = 0
-		charMax = 0
+		ablationTempThresh = 500
+		depletedMaxTemp = 1200
+		charMin = 1
+		charMax = 1
 	}
 }
 @PART[HOME_radial_engine]

--- a/DeadlyReentry/DeadlyReentry-KSO.cfg
+++ b/DeadlyReentry/DeadlyReentry-KSO.cfg
@@ -3,6 +3,11 @@
 @PART[omskso]
 {
 	@maxTemp = 2220
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 	@MODULE[ModuleEngines]
 	{
 		@heatProduction = 150
@@ -12,11 +17,21 @@
 @PART[avionicskso]:FOR[DeadlyReentry]
 {
 	@maxTemp = 1450
+	%emissiveConstant = 0.85
+	skinMaxTemp = 3000
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 }
 
 @PART[tailrudderkso]:FOR[DeadlyReentry]
 {
 	@maxTemp = 1450
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 }
 
 
@@ -24,6 +39,11 @@
 @PART[KSO_Cabin]:FOR[DeadlyReentry]
 {
 	@maxTemp = 1500
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
 }
@@ -31,6 +51,11 @@
 @PART[cgholdkso]:FOR[DeadlyReentry]
 {
 	@maxTemp = 1700
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
 }
@@ -38,6 +63,11 @@
 @PART[rearkso]:FOR[DeadlyReentry]
 {
 	@maxTemp = 1500
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
 }
@@ -45,6 +75,11 @@
 @PART[leftwingkso]:FOR[DeadlyReentry]
 {
 	@maxTemp = 1500
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
 }
@@ -52,6 +87,11 @@
 @PART[rightwingkso]:FOR[DeadlyReentry]
 {
 	@maxTemp = 1500
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
 }
@@ -59,6 +99,11 @@
 @PART[noseconekso]:FOR[DeadlyReentry]
 {
 	@maxTemp = 1500
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
 }
@@ -66,6 +111,11 @@
 @PART[nosegearkso]:FOR[DeadlyReentry]
 {
 	@maxTemp = 1500
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
 }
@@ -73,6 +123,11 @@
 @PART[rightgearkso]:FOR[DeadlyReentry]
 {
 	@maxTemp = 1500
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
 }
@@ -80,6 +135,11 @@
 @PART[leftgearkso]:FOR[DeadlyReentry]
 {
 	@maxTemp = 1500
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
 }
@@ -87,6 +147,11 @@
 @PART[rearplanekso]:FOR[DeadlyReentry]
 {
 	@maxTemp = 1500
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
 }
@@ -94,12 +159,22 @@
 @PART[leftelevkso]:FOR[DeadlyReentry]
 {
 	@maxTemp = 1500
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
 }
 @PART[rightelevkso]:FOR[DeadlyReentry]
 {
 	@maxTemp = 1500
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
 }

--- a/DeadlyReentry/DeadlyReentry-KSO25.cfg
+++ b/DeadlyReentry/DeadlyReentry-KSO25.cfg
@@ -3,6 +3,11 @@
 @PART[super25rudderkso]:FOR[DeadlyReentry]
 {
 	@maxTemp = 1450
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 }
 @PART[KSO25_Cabin]:FOR[DeadlyReentry]
 {
@@ -10,11 +15,14 @@
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
 	!RESOURCE[Ablator]{}
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 	MODULE
 	{
@@ -32,6 +40,11 @@
 	@maxTemp = 1500
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 }
 
 @PART[super25wingRkso]:FOR[DeadlyReentry]
@@ -39,6 +52,11 @@
 	@maxTemp = 1500
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
+	%emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 }
 
 
@@ -47,6 +65,10 @@
 	@maxTemp = 1500
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
+	skinMaxTemp = 3000
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 }
 
 @PART[super25nosegearkso]:FOR[DeadlyReentry]
@@ -54,6 +76,10 @@
 	@maxTemp = 1500
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 }
 
 @PART[super25maingearRkso]:FOR[DeadlyReentry]
@@ -61,6 +87,10 @@
 	@maxTemp = 1500
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 }
 
 @PART[super25maingearLkso]:FOR[DeadlyReentry]
@@ -68,6 +98,10 @@
 	@maxTemp = 1500
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 }
 
 
@@ -77,6 +111,10 @@
 	@maxTemp = 1500
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 }
 
 @PART[super25surfaceLkso]:FOR[DeadlyReentry]
@@ -84,23 +122,18 @@
 	@maxTemp = 1500
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 }
 @PART[super25surfaceRkso]:FOR[DeadlyReentry]
 {
 	@maxTemp = 1500
 	!MODULE[ModuleHeatShield]{}
 	!RESOURCE[AblativeShielding]{}
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 }
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/DeadlyReentry/DeadlyReentry-KWRocketryFairings.cfg
+++ b/DeadlyReentry/DeadlyReentry-KWRocketryFairings.cfg
@@ -1,77 +1,70 @@
 @PART[KW2mSRBNoseCone]
 {
 	@maxTemp = 1523.15
+	skinInternalConductionMult = 0.012
+	skinMaxTemp = 2000
 	emissiveConstant = 0.6
 	{
 		name = ModuleAeroReentry
-		skinThicknessFactor = 0.1
-		skinHeatConductivity = 0.012
-		skinMaxTemp = 2000
 	}	
 }
 @PART[KW1mNoseCone]
 {
 	@maxTemp = 1523.15
+	skinInternalConductionMult = 0.012
+	skinMaxTemp = 2000
 	emissiveConstant = 0.6
 	{
 		name = ModuleAeroReentry
-		skinThicknessFactor = 0.1
-		skinHeatConductivity = 0.012
-		skinMaxTemp = 2000
 	}	
 }
 @PART[KW2mNoseCone]
 {
 	@maxTemp = 1523.15
+	skinInternalConductionMult = 0.012
+	skinMaxTemp = 2000
 	emissiveConstant = 0.6
 	{
 		name = ModuleAeroReentry
-		skinThicknessFactor = 0.1
-		skinHeatConductivity = 0.012
-		skinMaxTemp = 2000
 	}	
 }
 @PART[KW3mNoseCone]
 {
 	@maxTemp = 1523.15
+	%skinInternalConductionMult = 0.012
+	%skinMaxTemp = 2000
 	emissiveConstant = 0.6
 	{
 		name = ModuleAeroReentry
-		skinThicknessFactor = 0.1
-		skinHeatConductivity = 0.012
-		skinMaxTemp = 2000
 	}	
 }
 @PART[KW5mNoseCone]
 {
 	@maxTemp = 1523.15
+	%skinInternalConductionMult = 0.012
+	%skinMaxTemp = 2000
 	emissiveConstant = 0.6
 	{
 		name = ModuleAeroReentry
-		skinThicknessFactor = 0.1
-		skinHeatConductivity = 0.012
-		skinMaxTemp = 2000
 	}	
 }
 @PART[KW*FairingCone]
 {
 	@maxTemp = 1523.15
+	%skinInternalConductionMult = 0.012
+	%skinMaxTemp = 2000
 	emissiveConstant = 0.6
 	{
 		name = ModuleAeroReentry
-		skinThicknessFactor = 0.1
-		skinHeatConductivity = 0.012
-		skinMaxTemp = 2000
 	}	
 }
 @PART[KW*FairingWall]
 {
 	@maxTemp = 1523.15
+	%skinInternalConductionMult = 0.012
+	%skinMaxTemp = 2000
 	emissiveConstant = 0.6
 	{
 		name = ModuleAeroReentry
-		skinThicknessFactor = 0.1
-		skinHeatConductivity = 0.012
-		skinMaxTemp = 2000
 	}	
 }

--- a/DeadlyReentry/DeadlyReentry-Mk2Essentials.cfg
+++ b/DeadlyReentry/DeadlyReentry-Mk2Essentials.cfg
@@ -2,16 +2,28 @@
 {
 	@maxTemp = 1873.15
 	@emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105 // 0.00013518518
+	skinMassPerArea = 0.8148148148148148
 }
 
 @PART[mk2Decoupler]
 {
 	@maxTemp = 1973.15
 	@emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 }
 
 @PART[mk2Separator]
 {
 	@maxTemp = 1973.15
 	@emissiveConstant = 0.85
+	skinMaxTemp = 2130
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 }

--- a/DeadlyReentry/DeadlyReentry-MkIVEssentials.cfg
+++ b/DeadlyReentry/DeadlyReentry-MkIVEssentials.cfg
@@ -1,5 +1,9 @@
 @PART[MkIVDecoupler|MkIVSeparator]:FOR[DeadlyReentry]
 {
 	@maxTemp = 1973.15
-	@emissiveConstant = 0.85
+	%emissiveConstant = 0.85
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
 }

--- a/DeadlyReentry/DeadlyReentry-RealChutes.cfg
+++ b/DeadlyReentry/DeadlyReentry-RealChutes.cfg
@@ -1,6 +1,8 @@
+// Hey this doesn't work because caps don't use animations, they're just disabled meshes.
 @PART[*]:HAS[@MODULE[RealChuteModule]]:Final
 {
 	@maxTemp = 1423.15
+	kinMaxTemp = 2300
 }
 @PART[RC_radial]
 {

--- a/DeadlyReentry/DeadlyReentry-TTSPP.cfg
+++ b/DeadlyReentry/DeadlyReentry-TTSPP.cfg
@@ -1,5 +1,9 @@
 @PART[TTSPPnose]
 {
-	@maxTemp = 1773.15
+	@maxTemp = 1523.15
+	%skinMaxTemp = 2300
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
 	@emissiveConstant = 0.85
 }

--- a/DeadlyReentry/DeadlyReentry.cfg
+++ b/DeadlyReentry/DeadlyReentry.cfg
@@ -48,17 +48,17 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 
 
 // General config to add / convert modules
-@PART[*]:HAS[!MODULE[ModuleAeroReentry],@MODULE[ModuleAblator]]:AFTER[DeadlyReentry]
+@PART[*]:HAS[@MODULE[ModuleAblator]]:AFTER[DeadlyReentry]
 {
-	@maxTemp = 1300 // these really need to fail out right if they deplete
 	@MODULE[ModuleAblator]
 	{
 		@name = ModuleHeatShield
+		depletedMaxTemp = 1200
 		//@lossExp = -6000
 		//%lossConst = 20
 		//@pyrolysisLossFactor *= 0.1 // Needs to be cut to 1/10th for DRE
 		//%reentryConductivity = 0.01
-		@ablationTempThresh = 400
+		//@ablationTempThresh = 400
 		//skinHeatConductivity = 0.5
 	}
 }
@@ -85,10 +85,10 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 		%leaveTemp = True
 	}
 }
-@PART[*]:HAS[~emissiveConstant[]]
-{
-	emissiveConstant = 0.2
-}
+//@PART[*]:HAS[~emissiveConstant[]]
+//{
+//	emissiveConstant = 0.2
+//}
 
 // Parts specific configs
 @PART[HeatShield1|HeatShield2|HeatShield3]:FOR[DeadlyReentry]
@@ -98,9 +98,14 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 	@MODULE[ModuleAblator]
 	{
 		@name = ModuleHeatShield
-		@ablationTempThresh = 400
+		//@ablationTempThresh = 400
 		@reentryConductivity = 0.01
 	}
+}
+
+@PART[airbrake1]
+{
+	@emissiveConstant = 0.6
 }
 
 @PART[mk1pod]:FOR[DeadlyReentry]
@@ -505,6 +510,15 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 	}
 }
 @PART[toroidalFuelTank]
+{
+	@maxTemp = 1073.15
+	MODULE
+	{
+		name = ModuleAeroReentry
+		skinMaxTemp = 2000
+	}
+}
+@PART[Size3to2Adapter]
 {
 	@maxTemp = 1073.15
 	MODULE
@@ -1092,4 +1106,10 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 @PART[B9_Shuttle_TailWing]
 {
 	emissiveConstant = 0.65
+}
+
+// DRE specific edit of Oblivion shield
+@PART[ObConicalHeatShield1|ObConicalHeatShield2|ObConicalHeatShield3]:FOR[DeadlyReentry]
+{
+	@thermalMassModifier = 1.0
 }

--- a/DeadlyReentry/DeadlyReentry.cfg
+++ b/DeadlyReentry/DeadlyReentry.cfg
@@ -5,7 +5,6 @@
 REENTRY_EFFECTS
 {
 	name = Default
-	machMultiplier = 2
 	ridiculousMaxTemp = 1523.15
 	maxTempScale = 0.5
 }
@@ -13,15 +12,15 @@ REENTRY_EFFECTS
 // Override Physics.cfg
 @PHYSICSGLOBALS:FOR[DeadlyReentry]
 {
-	@radiationFactor = 10.0
-	@convectionFactor = 10.0
-	@conductionFactor = 1.0
-	@internalHeatProductionFactor = 0.03
-	@aerodynamicHeatProductionFactor = 1.0
-	@standardSpecificHeatCapacity = 800
-	@fullConvectionAreaMin = -0.2
-	@convectionDensityExponent = 0.6
-	@machConvectionExponent = 4
+	//@radiationFactor = 6.0
+	//@convectionFactor = 6.0
+	@conductionFactor = 3.33
+	//@internalHeatProductionFactor = 0.03
+	//@aerodynamicHeatProductionFactor = 1.0
+	//@standardSpecificHeatCapacity = 800
+	//@fullConvectionAreaMin = -0.2
+	//@convectionDensityExponent = 0.6
+	//@machConvectionExponent = 4
 }
 
 
@@ -30,7 +29,7 @@ RESOURCE_DEFINITION
 {
 	name = AblativeShielding
 	density = 0.001
-	hsp = 100
+	hsp = 400
 	flowMode = NO_FLOW
 	transfer = NONE
 	unitCost = 0.5
@@ -50,27 +49,17 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 // General config to add / convert modules
 @PART[*]:HAS[@MODULE[ModuleAblator]]:AFTER[DeadlyReentry]
 {
+	%leaveTemp = True
 	@MODULE[ModuleAblator]
 	{
 		@name = ModuleHeatShield
+		@reentryConductivity = 0.01
+		@lossExp = -6000
+		@lossConst = 5
+		@pyrolysisLossFactor = 120
 		depletedMaxTemp = 1200
-		//@lossExp = -6000
-		//%lossConst = 20
-		//@pyrolysisLossFactor *= 0.1 // Needs to be cut to 1/10th for DRE
-		//%reentryConductivity = 0.01
-		//@ablationTempThresh = 400
-		//skinHeatConductivity = 0.5
 	}
 }
-//@PART[*]:HAS[!MODULE[ModuleAeroReentry],!MODULE[ModuleHeatShield]]:AFTER[DeadlyReentry]
-//{
-//	MODULE
-//	{
-//		name = ModuleAeroReentry
-//		skinHeatConductivity = 0.12
-//		leaveTemp = False
-//	}
-//}
 @PART[*]:HAS[@MODULE[ModuleAeroReentry],#leaveTemp[*]]:FINAL
 {
 	@MODULE[ModuleAeroReentry]
@@ -93,44 +82,42 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 // Parts specific configs
 @PART[HeatShield1|HeatShield2|HeatShield3]:FOR[DeadlyReentry]
 {
-	@maxTemp = 1600
-	@thermalMassModifier = 1
 	@MODULE[ModuleAblator]
 	{
 		@name = ModuleHeatShield
-		//@ablationTempThresh = 400
 		@reentryConductivity = 0.01
+		@lossExp = -6000
+		@lossConst = 5
+		@pyrolysisLossFactor = 120
+		depletedMaxTemp = 1200
+		leaveTemp = True
 	}
 }
 
 @PART[airbrake1]
 {
-	@emissiveConstant = 0.6
+	//@emissiveConstant = 0.6
+	%maxSkinTemp = 2300
+	%leaveTemp = true
 }
 
 @PART[mk1pod]:FOR[DeadlyReentry]
 {
-	@maxTemp = 1600
+	skinInternalConductionMult = 0.0001
+
 	MODULE
 	{
-		// Most of these if unspecified default to the corresponding part variable.
-		// skinMaxTemp
-		// skinThermalMassModifier
-		// skinThicknessFactor = 0.1
-		// skinHeatConductivity = 0.12
-		// skinThermalMass
-
 		name = ModuleHeatShield
 		ablativeResource = AblativeShielding
 		lossExp = -5000
-		lossConst = 20
-		pyrolysisLossFactor = 10000
+		lossConst = 5
+		pyrolysisLossFactor = 120
 		reentryConductivity = 0.01
 		ablationTempThresh = 500
 		depletedMaxTemp = 1200
-		reentryConductivity = 0.0012 // (skinHeatConductivity * default reentryConductivity)
-		charMin = 0
-		charMax = 0
+		charMin = 1
+		charMax = 1
+		charAlpha = 1
 	}
 	RESOURCE
 	{
@@ -140,162 +127,147 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 	}
 }
 
-@PART[NASAaeroShield_A]:FOR[DeadlyReentry]
+@PART[fairingSize1]
 {
-	@node_stack_bottom = 0.0, -0.95, 0.0, 0.0, -1.0, 0.0, 1
-	@mass = 0.675
-	CoPOffset = 0, 0.75, 0
-	CoLOffset = 0, -0.855
-	thermalMassModifier = 1.6725
-	maxTemp = 2750 // 2086
-	heatConductivity = 0.01
-	emissiveConstant = 0.95
-	//heatConvectiveConstant
+	@skinInternalConductionMult *= 5.0
 	MODULE
 	{
-		name = ModuleAeroReentry
-		skinThicknessFactor = 0.5
-		//skinHeatConductivity = 0.0012
-		skinMaxTemp = 2750
+		name = ModuleHeatShield
+		ablativeResource = AblativeShielding
+		lossExp = -2500
+		lossConst = 5
+		pyrolysisLossFactor = 120
+		reentryConductivity = 0.01
+		ablationTempThresh = 500
+		depletedMaxTemp = 1200
+		charMin = 1
+		charMax = 1
+		charAlpha = 1
 	}
-	!MODULE[ModuleAnimation2Value],*{}
-	!MODULE[ModuleHeatShield]{}
-	!RESOURCE[AblativeShielding]{}
-	MODULE
-    {
-        name = ModuleAnimation2Value
-        animationName = AeroShieldOpen
-        valueName = emissiveConstant
-        valueCurve
-        {
-			key = 0 0.4 0 0.45
-			key = 1 0.95 0.45 0
-        }
-    }
 	RESOURCE
 	{
-		name = LeadBallast
-		amount = 0.0
-		maxAmount = 352.734
+		name = AblativeShielding
+		amount = 0
+		maxAmount = 100
 	}
 }
-@PART[NASAaeroShield_B]:FOR[DeadlyReentry]
+@PART[fairingSize2]
 {
-	@node_stack_bottom = 0.0, -1.9, 0.0, 0.0, -1.0, 0.0, 2
-	@mass = 1.2
-	CoPOffset = 0, 0.8925, 0
-	CoLOffset = 0, -1.71, 0
-	thermalMassModifier = 1.6725
-	maxTemp = 2750
-	heatConductivity = 0.01
-	emissiveConstant = 0.95
-
+	@skinInternalConductionMult *= 5.0
 	MODULE
 	{
-		name = ModuleAeroReentry
-		skinThicknessFactor = 0.5
-		//skinHeatConductivity = 0.0012
-		skinMaxTemp = 2750
+		name = ModuleHeatShield
+		ablativeResource = AblativeShielding
+		lossExp = -2500
+		lossConst = 5
+		pyrolysisLossFactor = 120
+		reentryConductivity = 0.01
+		ablationTempThresh = 500
+		depletedMaxTemp = 1200
+		charMin = 1
+		charMax = 1
+		charAlpha = 1
 	}
-	!MODULE[ModuleAnimation2Value],*{}
-	!MODULE[ModuleHeatShield]{}
-	!RESOURCE[AblativeShielding]{}
-	MODULE
-    {
-        name = ModuleAnimation2Value
-        animationName = AeroShieldOpen
-        valueName = emissiveConstant
-        valueCurve
-        {
-			key = 0 0.4 0 0.45
-			key = 1 0.95 0.45 0
-        }
-    }	
 	RESOURCE
 	{
-		name = LeadBallast
-		amount = 0.0
-		maxAmount = 352.734
+		name = AblativeShielding
+		amount = 0
+		maxAmount = 400
+	}
+}
+@PART[fairingSize3]
+{
+	@skinInternalConductionMult *= 5.0
+	MODULE
+	{
+		name = ModuleHeatShield
+		ablativeResource = AblativeShielding
+		lossExp = -2500
+		lossConst = 5
+		pyrolysisLossFactor = 120
+		reentryConductivity = 0.01
+		ablationTempThresh = 500
+		depletedMaxTemp = 1200
+		charMin = 1
+		charMax = 1
+		charAlpha = 1
+	}
+	RESOURCE
+	{
+		name = AblativeShielding
+		amount = 0
+		maxAmount = 1600
 	}
 }
 
 @PART[*]:HAS[@MODULE[ProceduralFairingSide]]
 {
-	@emissiveConstant = 0.6 // might have to increase this?
+	@emissiveConstant = 0.8 // might have to increase this?
+	@skinInternalConductionMult *= 5.0
+	MODULE
+	{
+		name = ModuleHeatShield
+		ablativeResource = AblativeShielding
+		lossExp = -2500
+		lossConst = 5
+		pyrolysisLossFactor = 120
+		reentryConductivity = 0.01
+		ablationTempThresh = 500
+		depletedMaxTemp = 1200
+		charMin = 1
+		charMax = 1
+		charAlpha = 1
+	}
+	RESOURCE
+	{
+		name = AblativeShielding
+		amount = 0
+		maxAmount = 1600
+	}
 }
 // Moved REENTRY_EFFECTS to DefaultSetting.cfg
 
 @PART[noseCone]
 {
 	@maxTemp = 1523.15 // 1700
+	%skinInternalConductionMult = 0.0012
+	%skinMaxTemp = 2300
 	emissiveConstant = 0.6
-	MODULE
-	{
-		name = ModuleAeroReentry
-		skinThicknessFactor = 0.1
-		skinHeatConductivity = 0.0012
-		skinMaxTemp = 2000
-	}	
 }
 @PART[noseConeAdapter]
 {
 	@maxTemp = 1523.15 // 1700
-	emissiveConstant = 0.6
-	MODULE
-	{
-		name = ModuleAeroReentry
-		skinThicknessFactor = 0.1
-		skinHeatConductivity = 0.0012
-		skinMaxTemp = 2000
-	}	
+	@emissiveConstant = 0.6
+	%skinInternalConductionMult = 0.0012
+	%skinMaxTemp = 2000
 }
 @PART[rocketNoseCone]
 {
 	@maxTemp = 1523.15 // 1700
-	emissiveConstant = 0.6
-	MODULE
-	{
-		name = ModuleAeroReentry
-		skinThicknessFactor = 0.1
-		skinHeatConductivity = 0.0012
-		skinMaxTemp = 2000
-	}	
+	@emissiveConstant = 0.6
+	%skinInternalConductionMult = 0.0012
+	%skinMaxTemp = 2300
 }
 @PART[standardNoseCone]
 {
 	@maxTemp = 1523.15 // 1700
 	emissiveConstant = 0.85
-	MODULE
-	{
-		name = ModuleAeroReentry
-		skinThicknessFactor = 0.1
-		skinHeatConductivity = 0.0012
-		skinMaxTemp = 2000
-	}	
+	skinInternalConductionMult = 0.0012
+	skinMaxTemp = 2300
 }
 @PART[Mark1Cockpit]
 {
 	@maxTemp = 1523.15 // 1700
 	emissiveConstant = 0.85
-	MODULE
-	{
-		name = ModuleAeroReentry
-		skinThicknessFactor = 0.1
-		skinHeatConductivity = 0.0012
-		skinMaxTemp = 2086
-	}	
+	skinInternalConductionMult = 0.0012
+	skinMaxTemp = 2086
 }
 @PART[Mark2Cockpit]
 {
 	@maxTemp = 1523.15 // 1700
+	skinInternalConductionMult = 0.0012
+	skinMaxTemp = 2086
 	emissiveConstant = 0.85
-	MODULE
-	{
-		name = ModuleAeroReentry
-		skinThicknessFactor = 0.1
-		skinHeatConductivity = 0.0012
-		skinMaxTemp = 2086
-	}	
 }
 @PART[Mark1-2Pod]
 {
@@ -329,11 +301,6 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 @PART[landerCabinSmall]
 {
 	@maxTemp = 1523.15 // 1700
-}
-@PART[mark3Cockpit]
-{
-	@maxTemp = 1523.15 // 1700
-	emissiveConstant = 0.65
 }
 @PART[mk2LanderCabin]
 {
@@ -394,7 +361,6 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinThicknessFactor = 1
 	}
 }
 @PART[solarPanels1]
@@ -404,7 +370,6 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinThicknessFactor = 1
 		skinMaxTemp = 2000
 	}
 	MODULE
@@ -435,11 +400,10 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 {
 	@maxTemp = 1523.15 // 1600
 	emissiveConstant = 0.65
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinThicknessFactor = 1
-		skinMaxTemp = 2000
 	}
 	MODULE
 	{
@@ -480,7 +444,6 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinThicknessFactor = 1
 	}
 }
 @PART[solarPanels5]
@@ -489,7 +452,6 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinThicknessFactor = 1
 	}
 }
 @PART[MK1Fuselage]
@@ -503,118 +465,118 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 @PART[fuelTankSmallFlat]
 {
 	@maxTemp = 1073.15
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[toroidalFuelTank]
 {
 	@maxTemp = 1073.15
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[Size3to2Adapter]
 {
 	@maxTemp = 1073.15
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[Size3LargeTank]
 {
 	@maxTemp = 1073.15
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[Size3MediumTank]
 {
 	@maxTemp = 1073.15
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[Size3SmallTank]
 {
 	@maxTemp = 1073.15
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[MK1Fuselage]
 {
 	@maxTemp = 1073.15
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[RCSFuelTank]
 {
 	@maxTemp = 1073.15
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[RCSTank1-2]
 {
 	@maxTemp = 1073.15
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[fuelTank]
 {
 	@maxTemp = 1073.15
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[fuelTank1-2]
 {
 	@maxTemp = 1073.15
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[fuelTank2-2]
 {
 	@maxTemp = 1073.15
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[fuelTank3-2]
 {
 	@maxTemp = 1073.15
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[fuelTank4-2]
@@ -623,53 +585,52 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[fuelTankSmall]
 {
 	@maxTemp = 1073.15
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[fuelTank.long]
 {
 	@maxTemp = 1073.15
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[fuelTank_long]
 {
 	@maxTemp = 1073.15
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[miniFuelTank]
 {
 	@maxTemp = 1073.15
+	skinMaxTemp = 2000
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[mk3Fuselage]
 {
 	@maxTemp = 1500
+	skinMaxTemp = 2000
 	emissiveConstant = 0.85
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2000
 	}
 }
 @PART[mk3spacePlaneAdapter]
@@ -796,7 +757,7 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 	    {
 	        key = 0 2700 0 0
 	        key = 0.1 1250 0 0
-	        key = 1 1250 0 0
+	        key = 1 1 0 0
 	    }
 	}
 
@@ -870,7 +831,7 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 @PART[largeAdapter]
 {
 	@maxTemp = 800
-	%emissiveConstant = 0.6
+	@emissiveConstant = 0.6
 	MODULE
 	{
 		name = ModuleAeroReentry
@@ -902,8 +863,6 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 	MODULE
 	{
 		name = ModuleAeroReentry
-		@skinThicknessFactor = 1
-		@skint = 100
 	}
 }
 @PART[parachuteDrogue]
@@ -951,7 +910,7 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
     	name = ModuleAnimation2Value
 		animationName = cap
 		valueModule = ModuleAeroReentry
-		valueName = skinHeatConductivity
+		valueName = skinInternalConductionMult
     	valueCurve
 		{
 			key = 0.0 0.12
@@ -980,7 +939,7 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
     	name = ModuleAnimation2Value
 		animationName = cap
 		valueModule = ModuleAeroReentry
-		valueName = skinHeatConductivity
+		valueName = skinInternalConductionMult
     	valueCurve
 		{
 			key = 0.0 0.12
@@ -1107,9 +1066,78 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 {
 	emissiveConstant = 0.65
 }
+@PART[GearLarge]
+{
+
+	@maxTemp = 933.15
+	@emissiveConstant = 0.85
+	@thermalMassModifier = 1
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
+	%leaveTemp = True
+	MODULE
+	{
+		name = ModuleAeroReentry
+	}
+	MODULE
+	{
+    	name = ModuleAnimation2Value
+		animationName = LandingGearLargeDeploy
+		valueName = emissiveConstant
+    	valueCurve
+		{
+			key = 0.0 0.85
+			key = 1.0 0.4
+		}
+	}
+}
+@PART[GearMedium]
+{
+
+	@maxTemp = 933.15
+	@emissiveConstant = 0.85
+	@thermalMassModifier = 1
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
+	%leaveTemp = True
+	MODULE
+	{
+		name = ModuleAeroReentry
+	}
+	MODULE
+	{
+    	name = ModuleAnimation2Value
+		animationName = LandingGearMediumDeploy
+		valueName = emissiveConstant
+    	valueCurve
+		{
+			key = 0.0 0.85
+			key = 1.0 0.4
+		}
+	}
+}
 
 // DRE specific edit of Oblivion shield
 @PART[ObConicalHeatShield1|ObConicalHeatShield2|ObConicalHeatShield3]:FOR[DeadlyReentry]
 {
 	@thermalMassModifier = 1.0
+	MODULE
+	{
+		name = ModuleHeatShield
+		ablativeResource = AblativeShielding
+		lossExp = -6000
+		lossConst = 5
+		pyrolysisLossFactor = 120
+		reentryConductivity = 0.01
+		ablationTempThresh = 500
+		depletedMaxTemp = 1200
+		charMin = 1
+		charMax = 1
+		charAlpha = 1
+		leaveTemp = True
+	}
 }

--- a/DeadlyReentry/DeadlyReentry.version
+++ b/DeadlyReentry/DeadlyReentry.version
@@ -11,7 +11,7 @@
     "VERSION":
     {
         "MAJOR":7,
-        "MINOR":1,
+        "MINOR":2,
         "PATCH":0,
         "BUILD":0
     },
@@ -19,18 +19,18 @@
     {
         "MAJOR":1,
         "MINOR":0,
-        "PATCH":2
+        "PATCH":4
     },
     "KSP_VERSION_MIN":
     {
         "MAJOR":1,
         "MINOR":0,
-        "PATCH":0
+        "PATCH":4
     },
     "KSP_VERSION_MAX":
     {
         "MAJOR":1,
         "MINOR":0,
-        "PATCH":2
+        "PATCH":4
     }
 }

--- a/DeadlyReentry/Fairings.cfg
+++ b/DeadlyReentry/Fairings.cfg
@@ -1,5 +1,7 @@
 // both Squad and SPP wings
 @PART[*]:HAS[@MODULE[ProceduralFairingSide]]
 {
+	@maxTemp = 1523.15
+	skinMaxTemp = 2300
 	@emissiveConstant = 0.6 // might have to increase this?
 }

--- a/DeadlyReentry/Mk3.cfg
+++ b/DeadlyReentry/Mk3.cfg
@@ -2,163 +2,211 @@
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	@emissiveConstant = 0.85
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
+	%leaveTemp = True
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 }
 @PART[mk3FuselageLFO_50]
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
+	%leaveTemp = True
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 }
 @PART[mk3FuselageLFO_25]
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
+	%leaveTemp = True
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 }
 @PART[mk3FuselageLF_100]
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
+	%leaveTemp = True
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 }
 @PART[mk3FuselageLF_50]
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
+	%leaveTemp = True
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 }
 @PART[mk3FuselageLF_25]
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
+	%leaveTemp = True
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 }
 @PART[mk3FuselageMONO]
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
+	%leaveTemp = True
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
 	}
 }
 @PART[mk3CrewCabin]
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
+	%leaveTemp = True
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 }
 @PART[mk3Cockpit_Shuttle]
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
+	%leaveTemp = True
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 }
 @PART[mk3CargoBayM]
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
+	%leaveTemp = True
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 }
 @PART[mk3CargoBayL]
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
+	%leaveTemp = True
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 }
 @PART[mk3CargoBayS]
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
+	%leaveTemp = True
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 }
 @PART[adapterMk3-Mk2]
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
+	%leaveTemp = True
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 }
 @PART[wingShuttleDelta]
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	@thermalMassModifier = 1
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
+	%leaveTemp = True
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 }
 @PART[wingShuttleStrake|wingShuttleElevon1|elevonMk3|wingShuttleRudder|wingShuttleElevon2]
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	%skinMaxTemp = 2130
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
+	%leaveTemp = True
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 }

--- a/DeadlyReentry/OLDD.ADEPT.cfg
+++ b/DeadlyReentry/OLDD.ADEPT.cfg
@@ -1,0 +1,78 @@
+@PART[NASAaeroShield_A]:FOR[DeadlyReentry]
+{
+	@node_stack_bottom = 0.0, -0.95, 0.0, 0.0, -1.0, 0.0, 1
+	@mass = 0.675
+	CoPOffset = 0, 1.25, 0
+	CoLOffset = 0, -0.855, 0
+	thermalMassModifier = 1.6725
+	maxTemp = 3000 // 2086
+	heatConductivity = 0.0001
+	skinInternalConductionMult = 100.0
+	skinSkinConductionMult = 0.001
+	
+	emissiveConstant = 0.9
+
+	!MODULE[ModuleAnimation2Value],*{}
+	!MODULE[ModuleHeatShield]{}
+	!RESOURCE[AblativeShielding]{}
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
+	MODULE
+    {
+        name = ModuleAnimation2Value
+        animationName = AeroShieldOpen
+        valueName = emissiveConstant
+        valueCurve
+        {
+			key = 0 0.4 0 0.45
+			key = 1 0.9 0.45 0
+        }
+    }
+	DRAG_CUBE
+	{
+		cube = A, 3.453236,0.2462514,3.793824, 3.453499,0.2445548,2.328398, 4.211788,0.8483717,2.284246, 4.211788,0.7275141,2.899859, 3.440861,0.2397083,3.17176, 3.435616,0.2395502,3.154708, 0.7329605,-0.4317558,0.01379657, 3.952039,3.931084,4.148381
+		cube = B, 2.447304,0.2846191,3.802299, 2.447304,0.2872828,3.191567, 12.91215,0.3552167,1.571432, 12.91215,0.3090981,2.916059, 2.446854,0.2850594,3.196235, 2.446854,0.2847461,3.196235, 0.2970989,-0.4317558,0, 4.823762,3.931084,4.229565
+	}
+}
+@PART[NASAaeroShield_B]:FOR[DeadlyReentry]
+{
+	@node_stack_bottom = 0.0, -1.9, 0.0, 0.0, -1.0, 0.0, 2
+	@mass = 1.2
+	CoPOffset = 0, 1.45, 0
+	CoLOffset = 0, -1.71, 0
+	thermalMassModifier = 1.6725
+	maxTemp = 3000
+	heatConductivity = 0.0001
+	skinInternalConductionMult = 100.0
+	skinSkinConductionMult = 0.001
+
+	emissiveConstant = 0.9
+
+	!MODULE[ModuleAnimation2Value],*{}
+	!MODULE[ModuleHeatShield]{}
+	!RESOURCE[AblativeShielding]{}
+	MODULE
+	{
+		name = ModuleAeroReentry
+		leaveTemp = True
+	}
+	MODULE
+    {
+        name = ModuleAnimation2Value
+        animationName = AeroShieldOpen
+        valueName = emissiveConstant
+        valueCurve
+        {
+			key = 0 0.4 0 0.45
+			key = 1 0.9 0.45 0
+        }
+    }
+	DRAG_CUBE
+	{
+		cube = A, 13.81294,0.2462514,7.500245, 13.81399,0.2445548,4.576421, 16.84715,0.8483717,4.457905, 16.84715,0.7275141,5.722558, 13.76344,0.2397083,6.26428, 13.74246,0.2395502,6.197639, 1.465921,-0.8635116,0.02759314, 7.904078,7.862168,8.296762
+		cube = B, 9.789218,0.2846191,7.491842, 9.789218,0.2872828,6.294693, 51.64859,0.3552167,3.066786, 51.64859,0.3090981,5.722558, 9.787416,0.2850594,6.316071, 9.787416,0.2847461,6.316071, 0.5941978,-0.8635116,0, 9.647525,7.862168,8.459129
+	}
+}

--- a/DeadlyReentry/Parts/DRE_0625HS.cfg
+++ b/DeadlyReentry/Parts/DRE_0625HS.cfg
@@ -54,7 +54,7 @@ PART
 	breakingForce = 630
 	breakingTorque = 630
 
-	maxTemp = 1800
+	maxTemp = 3800
 
 	bulkheadProfiles = size0
 
@@ -65,12 +65,11 @@ PART
 		name = ModuleHeatShield
 		ablativeResource = AblativeShielding
 		lossExp = -6000
-		lossConst = 20
-		pyrolysisLossFactor = 10000
-		reentryConductivity = 0.025
+		lossConst = 5
+		pyrolysisLossFactor = 120
+		reentryConductivity = 0.01
 		ablationTempThresh = 500
-		skinHeatConductivity = 0.25
-
+		depletedMaxTemp = 1200
 	}
 	RESOURCE
 	{

--- a/DeadlyReentry/Parts/deadlyReentry_1.25Heatshield/part.cfg
+++ b/DeadlyReentry/Parts/deadlyReentry_1.25Heatshield/part.cfg
@@ -44,7 +44,7 @@ PART
 	breakingForce = 630
 	breakingTorque = 630
 
-	maxTemp = 1800
+	maxTemp = 3800
 
 	bulkheadProfiles = size1
 
@@ -55,12 +55,13 @@ PART
 		name = ModuleHeatShield
 		ablativeResource = AblativeShielding
 		lossExp = -6000
-		lossConst = 20
-		pyrolysisLossFactor = 10000
-		reentryConductivity = 0.025
+		lossConst = 5
+		pyrolysisLossFactor = 120
+		reentryConductivity = 0.01
 		ablationTempThresh = 500
-		skinHeatConductivity = 0.25
+		depletedMaxTemp = 1200
 	}
+
 	RESOURCE
 	{
 		name = AblativeShielding

--- a/DeadlyReentry/Parts/deadlyReentry_2.5Heatshield/part.cfg
+++ b/DeadlyReentry/Parts/deadlyReentry_2.5Heatshield/part.cfg
@@ -51,7 +51,7 @@ PART
 	minimum_drag = 0.1
 	angularDrag = 2
 	crashTolerance = 9
-	maxTemp = 1800
+	maxTemp = 3800
 
 	bulkheadProfiles = size2
 
@@ -63,12 +63,16 @@ PART
 		name = ModuleHeatShield
 		ablativeResource = AblativeShielding
 		lossExp = -6000
-		lossConst = 20
-		pyrolysisLossFactor = 10000
-		reentryConductivity = 0.025
+		lossConst = 5
+		pyrolysisLossFactor = 120
+		reentryConductivity = 0.01
 		ablationTempThresh = 500
-		skinHeatConductivity = 0.25
+		depletedMaxTemp = 1200
+		charMin = 1
+		charMax = 1
+		charAlpha = 1
 	}
+
 	RESOURCE
 	{
 		name = AblativeShielding

--- a/DeadlyReentry/Parts/deadlyReentry_3.75Heatshield/part.cfg
+++ b/DeadlyReentry/Parts/deadlyReentry_3.75Heatshield/part.cfg
@@ -45,7 +45,7 @@ PART
 	breakingForce = 630
 	breakingTorque = 630
 
-	maxTemp = 1800
+	maxTemp = 3800
 
 	bulkheadProfiles = size3
 
@@ -66,12 +66,13 @@ PART
 		name = ModuleHeatShield
 		ablativeResource = AblativeShielding
 		lossExp = -6000
-		lossConst = 20
-		pyrolysisLossFactor = 10000
-		reentryConductivity = 0.025
+		lossConst = 5
+		pyrolysisLossFactor = 120
+		reentryConductivity = 0.01
 		ablationTempThresh = 500
-		skinHeatConductivity = 0.25
+		depletedMaxTemp = 1200
 	}
+
 	RESOURCE
 	{
 		name = AblativeShielding

--- a/DeadlyReentry/Readme_DREC.txt
+++ b/DeadlyReentry/Readme_DREC.txt
@@ -23,6 +23,17 @@ Hold down ALT+D+R to enable debugging. This lets you change settings in-game, an
 
 ==========
 Changelog:
+v7.2.0
+* Deadly Reentry no longer implements reentry heating. Instead it tweaks parameters to make stock reentry deadlier.
+* Deadly Reentry still handles G-force damage.
+* Still no menu. (sorry! Cute cat still there!)
+* Configs for all parts previously handled by Deadly Reentry have been edited to take advantage of new stock skin system.
+* Spaceplane handling is a bit experimental and relies on having a skin with VERY low thermal mass which increases the heat loss from radiation. 
+  (use VERY shallow reentries for spaceplanes and reentries will be survivable but difficult. Consider turning off the heat gauges or you will get a frightful scare when you do spaceplane reentries)
+* (no, seriously, turn the heat gauges off...)
+* skinMaxTemp tends to be higher than maxTemp which now represents internal temp, including resource temp.
+* ModularFlightIntegrator is still a dependency but is not currently used by Deadly Reentry.
+
 v7.1.0
 * Added heat shield char support. (not all shields)
 * Major changes to skin conduction, radiation and convection

--- a/DeadlyReentry/SPP.cfg
+++ b/DeadlyReentry/SPP.cfg
@@ -2,11 +2,14 @@
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	@thermalMassModifier = 1
+	%skinMaxTemp = 2300
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 }
 
@@ -14,11 +17,14 @@
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	@thermalMassModifier = 1
+	%skinMaxTemp = 2300
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 }
 
@@ -26,10 +32,13 @@
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	@thermalMassModifier = 1
+	%skinMaxTemp = 2300
+	%skinThermalMassModifier = 0.436125055
+	%skinInternalConductionMult = 0.0000105
+	%skinMassPerArea = 0.8148148148148148
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
-		skinThermalMassModifier = 0.0784875
 	}
 }

--- a/DeadlyReentry/Wings.cfg
+++ b/DeadlyReentry/Wings.cfg
@@ -3,9 +3,13 @@
 {
 	@maxTemp = 933.15
 	@emissiveConstant = 0.85
+	@thermalMassModifier = 1
+	skinMaxTemp = 2300
+	skinThermalMassModifier = 0.436125055
+	skinInternalConductionMult = 0.0000105
+	skinMassPerArea = 0.8148148148148148
 	MODULE
 	{
 		name = ModuleAeroReentry
-		skinMaxTemp = 2130
 	}
 }

--- a/Source/DREFlightIntegrator.cs
+++ b/Source/DREFlightIntegrator.cs
@@ -29,6 +29,7 @@ namespace DeadlyReentry
 
         public void Start()
         {
+            /*
             return;
             print("Attempting to register ProcessUpdateConvectionOverride with ModularFlightIntegrator");
             bool result=false;
@@ -41,6 +42,7 @@ namespace DeadlyReentry
             result = ModularFlightIntegrator.RegisterUpdateRadiationOverride(ProcessUpdateRadiation);
             if (!result)
                 print("Unable to override stock radiant heating!");
+            */
         }
 
 

--- a/Source/DREFlightIntegrator.cs
+++ b/Source/DREFlightIntegrator.cs
@@ -29,6 +29,7 @@ namespace DeadlyReentry
 
         public void Start()
         {
+            return;
             print("Attempting to register ProcessUpdateConvectionOverride with ModularFlightIntegrator");
             bool result=false;
             result =  ModularFlightIntegrator.RegisterUpdateConvectionOverride(ProcessUpdateConvection);

--- a/Source/DeadlyReentry.sln
+++ b/Source/DeadlyReentry.sln
@@ -3,12 +3,18 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeadlyReentry", "DeadlyReentry.csproj", "{F6F826CC-5CED-421B-B05F-5758D402976A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularFlightIntegrator", "..\..\ModularFlightIntegrator\ModularFlightIntegrator.csproj", "{EE8094B7-3C3E-4BEE-B01A-5A83F36D745D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EE8094B7-3C3E-4BEE-B01A-5A83F36D745D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE8094B7-3C3E-4BEE-B01A-5A83F36D745D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE8094B7-3C3E-4BEE-B01A-5A83F36D745D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE8094B7-3C3E-4BEE-B01A-5A83F36D745D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F6F826CC-5CED-421B-B05F-5758D402976A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F6F826CC-5CED-421B-B05F-5758D402976A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F6F826CC-5CED-421B-B05F-5758D402976A}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Changelog:
v7.2.0
* Deadly Reentry no longer implements reentry heating. Instead it tweaks parameters to make stock reentry deadlier.
* Deadly Reentry still handles G-force damage.
* Still no menu. (sorry! Cute cat still there!)
* Configs for all parts previously handled by Deadly Reentry have been edited to take advantage of new stock skin system.
* Spaceplane handling is a bit experimental and relies on having a skin with VERY low thermal mass which increases the heat loss from radiation. 
  (use VERY shallow reentries for spaceplanes and reentries will be survivable but difficult. Consider turning off the heat gauges or you will get a frightful scare when you do spaceplane reentries)
* (no, seriously, turn the heat gauges off...)
* skinMaxTemp tends to be higher than maxTemp which now represents internal temp, including resource temp.
* ModularFlightIntegrator is still a dependency but is not currently used by Deadly Reentry.
