### PR TITLE
Don't apply ModuleAeroReentry to flags

### DIFF
--- a/DeadlyReentry/DeadlyReentry.cfg
+++ b/DeadlyReentry/DeadlyReentry.cfg
@@ -76,7 +76,7 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 	//!leaveTemp = DELETE
 }
 
-@PART[*]:HAS[!MODULE[ModuleAeroReentry]]:FINAL
+@PART[*]:HAS[~name[flag]]:HAS[!MODULE[ModuleAeroReentry]]:FINAL
 {
 	MODULE
 	{


### PR DESCRIPTION
Or they blow up when you place them.  Doesn't appear to be FAR related, haven't tested other mod combos, but this seems to be a pretty benign part to skip aerodynamic effects on.