### PR TITLE
Fix negative damage applied when a part's internal temperature goes over operational temp

### DIFF
--- a/Source/DeadlyReentry.cs
+++ b/Source/DeadlyReentry.cs
@@ -597,14 +597,15 @@ namespace DeadlyReentry
 
                     if (part.temperature > maxOperationalTemp)
                     {
-                        // for scream / fear reaction ratio, use scalding water as upper value
-                        float tempRatio = (float)RangePercent(maxOperationalTemp, 322.15, part.temperature);
+                        float tempRatio = (float)RangePercent(maxOperationalTemp, part.maxTemp, part.temperature);
 
                         if (part.mass > 1)
                             tempRatio /= part.mass;
                         
                         AddInternalDamage(TimeWarp.fixedDeltaTime * tempRatio);
 
+						// for scream / fear reaction ratio, use scalding water as upper value
+						tempRatio = Mathf.InverseLerp(313.15f, 322.15f, (float)part.temperature);
                         if (vessel.isEVA && tempRatio >= 0.089 && nextScream <= DateTime.Now)
                         {
                             ReentryReaction.Fire(new GameEvents.ExplosionReaction(0, tempRatio));

--- a/Source/DeadlyReentry.cs
+++ b/Source/DeadlyReentry.cs
@@ -624,8 +624,11 @@ namespace DeadlyReentry
                         float soundTempRatio = (float)(tempRatio);
                         PlaySound(ablationFX, soundTempRatio);
 
-                        if (vessel.isEVA)
+                        if (vessel.isEVA && nextScream <= DateTime.Now)
+						{
                             PlaySound(screamFX, 1f);
+							nextScream = DateTime.Now.AddSeconds(15);
+						}
 
                         if (damageCube.averageDamage >= 1.0f)
                         { // has it burnt up completely?


### PR DESCRIPTION
With the code as written, when operationalTemp for a part is > 322, the result of tempRatio will be negative. Due to the comment, I believe the original intent was to apply capping to the temp ratio just for scream and reaction purposes, not to cap (let alone make negative) all parts' damage.

This also includes a fix to kerbal screams where, while the internal temp scream checked vs nextScream, the skintemp version did not, leading to the PlaySound call being spammed every physics tick.