### PR TITLE
Two tweaks to cfgs

### DIFF
--- a/DeadlyReentry/DeadlyReentry-RealChutes.cfg
+++ b/DeadlyReentry/DeadlyReentry-RealChutes.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@MODULE[RealChuteModule]]:Final
+@PART[*]:HAS[@MODULE[RealChuteModule]]:LAST[DeadlyReentry]
 {
 	%emissiveConstant = 0.85
 	%maxTemp = 850
@@ -35,7 +35,7 @@
 		}
 	}
 }
-@PART[RC_cone*]:NEEDS[RealChute]:FINAL
+@PART[RC_cone*]:NEEDS[RealChute]:LAST[DeadlyReentry]
 {
 	MODULE
 	{

--- a/DeadlyReentry/DeadlyReentry-TaurusHCV.cfg
+++ b/DeadlyReentry/DeadlyReentry-TaurusHCV.cfg
@@ -1,4 +1,4 @@
-@PART[TaurusHeatshield]:FINAL
+@PART[TaurusHeatshield]:LAST[DeadlyReentry]
 {
 	@CoPOffset = 0, 1, 0
 	@CoLOffset = 0, 0, 0

--- a/DeadlyReentry/DeadlyReentry.cfg
+++ b/DeadlyReentry/DeadlyReentry.cfg
@@ -61,31 +61,35 @@ RESOURCE_DEFINITION:NEEDS[!RealFuels]
 		depletedMaxTemp = 1200
 	}
 }
-@PART[*]:HAS[@MODULE[ModuleAeroReentry],#leaveTemp[*]]:FINAL
+// RO parts get leavetemp regardless
+@PART[*]:HAS[#RSSROConfig[True]]:LAST[DeadlyReentry]
 {
-	@MODULE[ModuleAeroReentry]
+	%leaveTemp = True
+}
+// Now apply leaveTemp to the appropriate module
+// PARTs without ModuleKerbalAeroReentry get the ModuleAeroReentry added if they lack it
+// and the leaveTemp flag copied (they need the module as otherwise the flag will be lost
+// when the module is force-added when KSP loads the Space Center
+@PART[*]:HAS[#leaveTemp[*],!MODULE[ModuleKerbalAeroReentry]]:LAST[DeadlyReentry]
+{
+	%MODULE[ModuleAeroReentry]
 	{
 		%leaveTemp = #$../leaveTemp$
 	}
-	// Causing errors in Module Manager because it deletes leaveTemp BEFORE accessing it above.
-	//!leaveTemp = DELETE
 }
-@PART[*]:HAS[!MODULE[ModuleAeroReentry],#leaveTemp[*]]:FINAL
+// and parts with ModuleKerbalAeroReentry get the leaveTemp flag copied and
+// do not have the base module added.
+@PART[*]:HAS[#leaveTemp[*],@MODULE[ModuleKerbalAeroReentry]]:LAST[DeadlyReentry]
 {
-	MODULE
+	@MODULE[ModuleKerbalAeroReentry]
 	{
-		name = ModuleAeroReentry
-		leaveTemp = #$../leaveTemp$
+		%leaveTemp = #$../leaveTemp$
 	}
-	// Causing errors in Module Manager because it deletes leaveTemp BEFORE accessing it above.
-	//!leaveTemp = DELETE
 }
-@PART[*]:HAS[@MODULE[ModuleAeroReentry],#RSSROConfig[True]]:FINAL
+// Clean up after ourselves.
+@PART[*]:HAS[#leaveTemp[*]]:LAST[DeadlyReentry]
 {
-	@MODULE[ModuleAeroReentry]
-	{
-		%leaveTemp = True
-	}
+	!leaveTemp = DELETE
 }
 //@PART[*]:HAS[~emissiveConstant[]]
 //{


### PR DESCRIPTION
First, convert FINAL pass specifiers to LAST[DeadlyReentry] now that LAST is available, to allow some level of mod interaction.
Second, change leaveTemp handling so it plays nice with Kerbals and so it gets cleaned up afterwards rather than left in the PART as well as the MODULE (which causes PartLoader to spam errors about unknown fields during part compilation).