### PR TITLE
Damage internal flux fixes

### DIFF
--- a/Source/DeadlyReentry.cs
+++ b/Source/DeadlyReentry.cs
@@ -691,23 +691,13 @@ namespace DeadlyReentry
                             fxs[i].gameObject.SetActive(false);
                     }
                     // Now: If a hole got burned in our hull... start letting the fire in!
-                    if (part.machNumber >= 1)
+					double machLerp = Math.Pow(UtilMath.Clamp01((part.machNumber - PhysicsGlobals.NewtonianMachTempLerpStartMach) / (PhysicsGlobals.NewtonianMachTempLerpEndMach - PhysicsGlobals.NewtonianMachTempLerpStartMach)), PhysicsGlobals.NewtonianMachTempLerpExponent);
+                    double damage = UtilMath.Lerp(damageCube.averageDamage, damageCube.GetCubeDamageFacing(part.partTransform.InverseTransformDirection(-this.vessel.upAxis)), machLerp);
+					
+                    if (damage > 0d && part.ptd != null && part.ptd.postShockExtTemp > part.temperature)
                     {
-                        float damage = damageCube.GetCubeDamageFacing(part.partTransform.InverseTransformDirection(-this.vessel.upAxis));
-                        if (damage > 0f && part.ptd != null && part.ptd.postShockExtTemp > part.temperature)
-                        {
-                            double convectiveFluxLeak = part.thermalConvectionFlux * (1 - (part.temperature / part.ptd.postShockExtTemp)) * (double)damage;
-                            part.AddThermalFlux(convectiveFluxLeak);
-                        }
-                    }
-                    else
-                    {
-                        float damage = damageCube.averageDamage;
-                        if (damage > 0f && part.ptd != null)
-                        {
-                            double convectiveFluxLeak = (double)damage * Math.Abs(part.ptd.convectionFlux) * (1 - (part.temperature / part.ptd.postShockExtTemp));
-                            part.AddThermalFlux(convectiveFluxLeak);
-                        }
+						double convectiveFluxLeak = part.ptd.finalCoeff * (part.ptd.postShockExtTemp - part.temperature ) * damage;
+						part.AddThermalFlux(convectiveFluxLeak);
                     }
                 }
             }

--- a/Source/DeadlyReentry.cs
+++ b/Source/DeadlyReentry.cs
@@ -694,9 +694,9 @@ namespace DeadlyReentry
                     if (part.machNumber >= 1)
                     {
                         float damage = damageCube.GetCubeDamageFacing(part.partTransform.InverseTransformDirection(-this.vessel.upAxis));
-                        if (damage > 0f && vessel.externalTemperature > part.temperature)
+                        if (damage > 0f && part.ptd != null && part.ptd.postShockExtTemp > part.temperature)
                         {
-                            double convectiveFluxLeak = part.thermalConvectionFlux * (1 - (part.temperature / vessel.externalTemperature)) * (double)damage;
+                            double convectiveFluxLeak = part.thermalConvectionFlux * (1 - (part.temperature / part.ptd.postShockExtTemp)) * (double)damage;
                             part.AddThermalFlux(convectiveFluxLeak);
                         }
                     }


### PR DESCRIPTION
Three fixes to the extra flux applied when a part is damaged:
* Use postShock external temp in all cases, because that is the actual temperature outside the part (vessel.externalTemperature is the pre-shock temperature, which is not the actual temperature the part is subject to except in rare cases--and in those cases postShock temp is equivalent).
* Don't double-count temperature by using flux, instead use the coefficient. In particular, heat transfer is proportional to the coefficient times the temperature delta (by definition of the coefficient); using flux but scaling it by a function of temperature uses temperature twice.
* Lerp between newtonian and mach convection in the same way FlightIntegrator does, rather than having a sharp break at Mach 1. This preserves consistency with the rest of KSP's convective thermo model, and respects whatever PhysicsGlobals settings a KSP install has.