### PR TITLE
Simply and fix OPT config

### DIFF
--- a/DeadlyReentry/DeadlyReentry-OPT.cfg
+++ b/DeadlyReentry/DeadlyReentry-OPT.cfg
@@ -1,4 +1,4 @@
-@PART[j_4m_crew|ij_4m_adaptor_variant|ij_adaptor|i_4m_cockpit_isp|ils_cockpit|mk23_cockpit|jk_3m_adaptor|jk_7m_adaptor|j_2m_bicoupler|j_4m_drone|j_engineMount_4|j_4m_tanks|j_4m_lab|j_4m_tail|j_cockpit|j_cockpit_qs|j_dropBay|k_2m_bicoupler|k_6m_cargo|k_6m_cargoTail|k_6m_tanks|k_8m_cockpit|mk2j_adaptor|opt_mk2_cockpit|mk2_ramIntake|opt_stabilizer_a|opt_winglet_a|opt_winglet_b|opt_winglet_c|opt_wing_a]
+@PART:HAS[#manufacturer[OPT?Aerospace?Division]]
 {
 	%maxTemp = 850
 	%skinMaxTemp = 2706
@@ -7,122 +7,7 @@
 	%skinMassPerArea = 0.815
 	%absorptiveConstant = 0.15
 	%emissiveConstant = 0.85
-	
 	%thermalMassModifier = 1.0 // If this EVER changes then skinThermalMassModifier needs to be divided by same amount!
-	MODULE
-	{
-		name = ModuleAeroReentry
-		leaveTemp = true
-		skinMaxOperationalTemp = 2706
-	}
-}
-// new section just to keep things from becoming unwieldy. Same set of configs
-@PART[j_docking_port|j_cockpitv2|opt_stabilizer_b]
-{
-	%maxTemp = 850
-	%skinMaxTemp = 2706
-	%skinThermalMassModifier = 0.43613
-	%skinInternalConductionMult = 0.0000105
-	%skinMassPerArea = 0.815
-	%absorptiveConstant = 0.15	
-	%emissiveConstant = 0.85
-	%thermalMassModifier = 1.0
-	MODULE
-	{
-		name = ModuleAeroReentry
-		leaveTemp = true
-		skinMaxOperationalTemp = 2706
-	}
-}
-
-
-//H_Fuselages
-@PART[h_2m_em_fm|h_2m_em_mm|h_2m_nose_fm|h_2m_nose_mm|h_3m_crew_fm|h_3m_crew_mm|h_3m_fuel_fm|h_3m_fuel_mm|h_4m_nose_fm|h_4m_nose_mm|h_drone_fm|h_drone_mm]
-{
-	%maxTemp = 850
-	%skinMaxTemp = 2706
-	%skinThermalMassModifier = 0.43613
-	%skinInternalConductionMult = 0.0000105
-	%skinMassPerArea = 0.815
-	%absorptiveConstant = 0.15
-	%emissiveConstant = 0.85
-	
-	%thermalMassModifier = 1.0 // If this EVER changes then skinThermalMassModifier needs to be divided by same amount!
-	MODULE
-	{
-		name = ModuleAeroReentry
-		leaveTemp = true
-		skinMaxOperationalTemp = 2706
-	}
-}
-//J_Fuselages
-@PART[ij_adaptor|ij_4m_adaptor_variant|j_2m_tanks|j_2m_inlineBoardingRamp|j_deploymentBay|j_3m_rearHatch|j_4m_cargo|j_4m_crew|j_engineMount_4|j_4m_tanks|j_4m_lab|j_4m_service|j_4m_drone|j_4m_droneRCS|j_sas|mk2j_adaptor]
-{
-	%maxTemp = 850
-	%skinMaxTemp = 2706
-	%skinThermalMassModifier = 0.43613
-	%skinInternalConductionMult = 0.0000105
-	%skinMassPerArea = 0.815
-	%absorptiveConstant = 0.15
-	%emissiveConstant = 0.85
-	
-	%thermalMassModifier = 1.0 // If this EVER changes then skinThermalMassModifier needs to be divided by same amount!
-	MODULE
-	{
-		name = ModuleAeroReentry
-		leaveTemp = true
-		skinMaxOperationalTemp = 2706
-	}
-}
-//K_Fuselages
-@PART[jk_3m_adaptor|jk_7m_adaptor|k_3m_fuelTank|k_3m_fuselage|k_6m_cargo|k_6m_fuelTank|k_6m_fuselage|k_7m_cargoTail|k_7m_cargoTail_variant]
-{
-	%maxTemp = 850
-	%skinMaxTemp = 2706
-	%skinThermalMassModifier = 0.43613
-	%skinInternalConductionMult =﻿ 0.0000105
-	%skinMassPerArea = 0.815
-	%absorptiveConstant = 0.15
-	%emissiveConstant = 0.85
-	
-	%thermalMassModifier = 1.0 // If this EVER changes then skinThermalMassModifier needs to be divided by same amount!
-	MODULE
-	{
-		name = ModuleAeroReentry
-		leaveTemp = true
-		skinMaxOperationalTemp = 2706
-	}
-}
-//KH_Fuselages
-@PART[kh_3m_cargo|kh_3m_fuselage|kh_6m_cargo|kh_6m_fuselage|kh_7m_cargoTail|kh_7m_cargoTail_variant]
-{
-	%maxTemp = 850
-	%skinMaxTemp = 2706
-	%skinThermalMassModifier = 0.43613
-	%skinInternalConductionMult = 0.0000105
-	%skinMassPerArea = 0.815
-	%absorptiveConstant = 0.15
-	%emissiveConstant = 0.85
-	
-	%thermalMassModifier = 1.0 // If this EVER changes then skinThermalMassModifier needs to be divided by same amount!
-	MODULE
-	{
-		name = ModuleAeroReentry
-		leaveTemp = true
-		skinMaxOperationalTemp = 2706
-	}
-}
-//Basic_Cockpits_and_nosecones
-@PART[i_4m_cockpit_isp|mk2_nose_opt|mk2_cockpitv2|mk2_cockpit|mk3_shuttle_noseCone|mk3Cockpit_Airliner|i_4m_cockpit_ispb|ils_cockpit_mki|mk23_cockpit]
-{
-	%maxTemp = 850
-	%skinMaxTemp = 2706
-	%skinThermalMassModifier = 0.43613
-	%skinInternalConductionMult = 0.0000105
-	%skinMassPerArea = 0.815
-	%absorptiveConstant = 0.15	
-	%emissiveConstant = 0.85
-	%thermalMassModifier = 1.0
 	MODULE
 	{
 		name = ModuleAeroReentry
@@ -133,23 +18,20 @@
 //Hi_Tech_Cockpits_and_nosecones
 @PART[phoenix_cockpit|ils_cockpitv2|j_5m_nose|j_6m_cockpit|j_cockpitv2|j_cockpit_qs|j_cockpit_qs_no_intake|k_10m_cockpit]
 {
-	%maxTemp = 850
 	%skinMaxTemp = 2950
-	%skinThermalMassModifier = 0.43613
-	%skinInternalConductionMult = 0.0000105
-	%skinMassPerArea = 0.815
-	%absorptiveConstant = 0.15	
-	%emissiveConstant = 0.85
-	%thermalMassModifier = 1.0
-	MODULE
-	{
-		name = ModuleAeroReentry
-		leaveTemp = true
-		skinMaxOperationalTemp = 2706
-	}
 }
 //Wings_and_solid_parts
-@PART[j_2m_bicoupler|i_4m_tail|j_docking_port|j_large_docking_port|j_5m_tail|k_2m_bicoupler|k_3m_tricoupler|mk2_ramIntake|opt_pylon_a|opt_pylon_b|opt_stabilizer_a|opt_stabilizer_b|opt_wing_a|opt_wing_a_elevon|opt_wing_b|opt_wing_b_elevon|opt_wing_c|opt_wing_c_elevon1|opt_wing_c_elevon2|opt_winglet_a|opt_winglet_a_elevon|opt_winglet_b|opt_winglet_b_elevon|opt_winglet_c|opt_winglet_c_elevon|mk2_ramIntake|OPTantenna]
+@PART[j_2m_bicoupler|i_4m_tail|j_docking_port|j_large_docking_port|j_5m_tail|k_2m_bicoupler|k_3m_tricoupler|OPTantenna]
+{
+	%maxTemp = 1500
+}
+@PART:HAS[#manufacturer[OPT*Division],#category[Aero]]
+{
+	%maxTemp = 1500
+}
+
+//Engines_and_RCS
+@PART:HAS[#manufacturer[OPT?Propulsion?Sicience?Division]]
 {
 	%maxTemp = 1500
 	%skinMaxTemp = 2706
@@ -158,7 +40,7 @@
 	%skinMassPerArea = 0.815
 	%absorptiveConstant = 0.15	
 	%emissiveConstant = 0.85
-	%thermalMassModifier = 1.0
+	%thermalMassModifier = 1.0 // If this EVER changes then skinThermalMassModifier needs to be divided by same amount!
 	MODULE
 	{
 		name = ModuleAeroReentry
@@ -167,22 +49,3 @@
 		skinMaxOperationalTemp = 2706
 	}
 }
-//Engines_and_RCS
-@PART[AAengine|engine_darkDrive|opt_mk2_engine_short|opt_nebula_engine|j_linear_aerospike|opt_oms_black|opt_oms_grey|opt_rcs_black|opt_rcs_grey|opt_retro_rcs]
-{
-	%maxTemp = 1500
-	%skinMaxTemp = 2706
-	%skinThermalMassModifier = 0.43613
-	%skinInternalConductionMult = 0.0000105
-	%skinMassPerArea = 0.815
-	%absorptiveConstant = 0.15	
-	%emissiveConstant = 0.85
-	%thermalMassModifier = 1.0
-	MODULE
-	{
-		name = ModuleAeroReentry
-		leaveTemp = true
-		maxOperationalTemp = 698.15
-		skinMaxOperationalTemp = 2706
-	}
-}﻿


### PR DESCRIPTION
* Condense redundant/default config blocks.
* Use OPT manufacturers (there are two) as the default filters for parts. This will automatically cover all parts, even new ones that get added from time to time.
* Fix ghost character issue that apeared in some values and caused 6+ OPT parts to be treated by KSP as invalid.